### PR TITLE
Lorawan Signal Strength Bug Fix

### DIFF
--- a/components/apis/beehive.ts
+++ b/components/apis/beehive.ts
@@ -517,7 +517,7 @@ export async function getPluginCounts(props: PluginCountsProps) : Promise<Record
 async function getRssi(vsn: string, devEui: string) : Promise<Record> {
   const params = {start: NODE_STATUS_RANGE, filter: {name: 'signal.rssi', vsn, devEui}, tail: 1}
   const metrics = await getData(params)
-  return metrics[1]
+  return metrics[metrics.length - 1]
 }
 
 export const fetchDataWithRssi = async (manifest: FlattenedManifest): Promise<LorawanConnection[]> => {


### PR DESCRIPTION
This is a very small bug fix, I had one line of code wrong causing the signal strength icon to not show up. Whenever you deploy can you also deploy to Crocus sage portal